### PR TITLE
Updated setup-php version and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ No outputs.
 ## Example usage
 
 ```yaml
-uses: axelerant/platformsh-deploy-action@v1
+uses: axelerant/platformsh-deploy-action@v1.0.1
 with:
   project-id: ${{ secrets.PlatformProjectId }}
   cli-token: ${{ secrets.PlatformCliToken }}

--- a/action.yml
+++ b/action.yml
@@ -20,7 +20,7 @@ runs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
-    - uses: shivammathur/setup-php@v2
+    - uses: shivammathur/setup-php@2.16.0
       with:
         php-version: ${{ inputs.php-version }}
     - uses: adam7/platformsh-cli-action@v1.1


### PR DESCRIPTION
Noticed that it was erroring out with `axelerant/platformsh-deploy-action@v1` as below. so updated it in Readme
<img width="921" alt="image" src="https://user-images.githubusercontent.com/23462578/149944029-874e3193-0b4d-4571-90fa-5eb32dc5220c.png">

Also there is an [fix provided in latest version of setup-php](https://github.com/shivammathur/setup-php/issues/538) for below error
<img width="1255" alt="image" src="https://user-images.githubusercontent.com/23462578/149944222-8cea9ed9-b49c-4fb7-bfa6-0f2d77bec01a.png">
